### PR TITLE
支払い方法の画像の追加、ログイン後の画面の編集、ライトモードとダークモード追加

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -61,7 +61,6 @@ class PaymentController extends Controller
             'onlymypayment' => $onlymypayment
         ]);
     }
-
     
     public function mypayment(Request $request, mypayment $mypayment, Payment $payment)
     {
@@ -76,6 +75,19 @@ class PaymentController extends Controller
             "payments"   => Payment::all(),
             "registered" => $registered,
             "message"    => "登録が完了しました",
+        ]);
+    }
+    
+    public function dashboard()
+    {
+        $user = Auth::user();
+        $registered = $user->mypayments()->pluck('payment_id')->toArray();
+        // ここで全件の決済方法を取得
+        $payments = \App\Models\Payment::all();
+    
+        return Inertia::render('Dashboard', [
+             'payments'   => $payments,
+             'registered' => $registered,
         ]);
     }
 

--- a/database/seeders/PaymentSeeder.php
+++ b/database/seeders/PaymentSeeder.php
@@ -18,75 +18,75 @@ class PaymentSeeder extends Seeder
     {
         DB::table('payments')->insert([
                 'name' => '楽天ペイ',
-                'image_path' => 'null'
+                'image_path' => 'https://finance.jp.rakuten-static.com/rpay/img/1/common/OGP_202310.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'PayPay',
-                'image_path' => 'null'
+                'image_path' => 'https://www.paygent.co.jp/files/user/images/logo_paypay_01.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'LINE Pay',
-                'image_path' => 'null'
+                'image_path' => 'https://d.line-scdn.net/linepay/merchant/center/images/devcenter/logo/logo_guide_color_default2_1.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'メルペイ',
-                'image_path' => 'null'
+                'image_path' => 'https://お財布レス.com/wp-content/uploads/2019/09/merpayimg.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'ｄ払い',
-                'image_path' => 'null'
+                'image_path' => 'https://www.ny-onlinestore.com/img/usr/page_top/news/logo_dbarai.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'au PAY',
-                'image_path' => 'null'
+                'image_path' => 'https://1tak.net/wp-content/uploads/2023/05/aupay017-640x360.jpeg'
         ]);
         DB::table('payments')->insert([
                 'name' => 'FamiPay',
-                'image_path' => 'null'
+                'image_path' => 'https://famipay.famidigi.jp/wp-content/themes/famidigi/images/common/ogp.jpg'
         ]);
         DB::table('payments')->insert([
                 'name' => 'Suica',
-                'image_path' => 'null'
+                'image_path' => 'https://www.jreast.co.jp/suicamoney/cp/specialcard/material/img/lp/mv_suica01-card.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'PASMO',
-                'image_path' => 'null'
+                'image_path' => 'https://www.keio.co.jp/assets/img/train/ticket/pasmo/img_pasmo.webp'
         ]);
         DB::table('payments')->insert([
                 'name' => 'イオンカード',
-                'image_path' => 'null'
+                'image_path' => 'https://www.aeon.co.jp/-/media/AeonCard/common/cardface/card_147_v'
         ]);
         DB::table('payments')->insert([
                 'name' => '三井住友カード',
-                'image_path' => 'null'
+                'image_path' => 'https://www.smbc-card.com/top_assets/img/img_recomend-card_classic.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'ｄカード',
-                'image_path' => 'null'
+                'image_path' => 'https://img1.kakaku.k-img.com/images/card/face/059001_0.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'JCBカード',
-                'image_path' => 'null'
+                'image_path' => 'https://www.okigin-jcb.co.jp/card_s/images/user/card1.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'エポスカード',
-                'image_path' => 'null'
+                'image_path' => 'https://dime.jp/wp-content/uploads/2020/08/4c85c234076325c638e2c305400f29d6-1.jpg'
         ]);
         DB::table('payments')->insert([
                 'name' => 'アメリカン・エキスプレス',
-                'image_path' => 'null'
+                'image_path' => 'https://icm.aexp-static.com/Internet/internationalcardshop/ja_jp/images/cards/gold-preferred-card.png'
         ]);
         DB::table('payments')->insert([
                 'name' => '三菱UFJカード',
-                'image_path' => 'null'
+                'image_path' => 'https://img1.kakaku.k-img.com/images/card/face/007005_0.png'
         ]);
         DB::table('payments')->insert([
                 'name' => 'セゾンカード',
-                'image_path' => 'null'
+                'image_path' => 'https://www.saisoncard.co.jp/proxy_img/assets/462949b256274358947c3db996c948d4/75c5da7e889347f38010ae9ca8bbffda/2110_14V2_digital_visa.png?auto=format&w=864'
         ]);
         DB::table('payments')->insert([
                 'name' => '現金',
-                'image_path' => 'null'
+                'image_path' => 'https://tk.ismcdn.jp/mwimgs/f/0/1200w/img_f0cc12720e56e60110a88cc21eb6e109280113.jpg'
         ]);
     }
 }

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -22,13 +22,13 @@ export default function Authenticated({ auth, header, children }) {
 
                             <div className="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
                                 <NavLink href={route('dashboard')} active={route().current('dashboard')}>
-                                    Dashboard
+                                    ホーム
                                 </NavLink>
                                 <NavLink href="/index" active={window.location.pathname === '/index'}>
-                                    Index
+                                    登録
                                 </NavLink>
                                 <NavLink href="/best" active={window.location.pathname === '/best'}>
-                                    Best
+                                    検索
                                 </NavLink>
                             </div>
                         </div>

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -1,22 +1,91 @@
-import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import React, { useState, useEffect } from 'react';
+import { ThemeProvider, CssBaseline, Button, Typography, Card, CardContent, FormControlLabel, Switch } from '@mui/material';
 import { Head } from '@inertiajs/react';
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { lightTheme, darkTheme } from '@/Themes/theme';
 
-export default function Dashboard(props) {
-    return (
-        <AuthenticatedLayout
-            auth={props.auth}
-            errors={props.errors}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Dashboard</h2>}
+export default function Dashboard({ auth, errors, payments = [], registered = [] }) {
+  const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark');
+
+  useEffect(() => {
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+  }, [darkMode]);
+
+  const registeredPayments = payments.filter(payment => registered.includes(payment.id));
+
+  return (
+    <ThemeProvider theme={darkMode ? darkTheme : lightTheme}>
+      <CssBaseline />
+      <AuthenticatedLayout auth={auth} errors={errors}>
+        <Head title="Dashboard" />
+        
+        {/* ダークモード切り替えスイッチ */}
+        <div style={{ position: 'absolute', top: 10, right: 60 }}>
+          <FormControlLabel
+            control={
+              <Switch 
+                checked={darkMode} 
+                onChange={() => setDarkMode(!darkMode)}
+                name="themeSwitch"
+                color="primary"
+              />
+            }
+            label={<span style={{ color: '#000' }}> {darkMode ? "D" : "L"} </span>}
+          />
+        </div>
+        
+        <div
+          className="py-12 min-h-screen flex flex-col items-center justify-start"
+          style={{ backgroundColor: darkMode ? darkTheme.palette.background.default : lightTheme.palette.background.default }}
         >
-            <Head title="Dashboard" />
-
-            <div className="py-12">
-                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div className="p-6 text-gray-900">You're logged in!</div>
-                    </div>
-                </div>
+          <div
+            className="max-w-3xl w-full shadow-md rounded-lg p-8 text-center mb-10"
+            style={{ backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper }}
+          >
+            <h1 className="text-3xl font-bold mb-4" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+              ようこそ！
+            </h1>
+            <p className="mb-6" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+              このページでは、登録済みの決済方法を確認できます。
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button variant="contained" color="primary" onClick={() => (window.location.href = '/index')}>
+                自分の支払い方法を登録する
+              </Button>
+              <Button variant="contained" color="secondary" onClick={() => (window.location.href = '/best')}>
+                お得な支払い方法を検索する
+              </Button>
             </div>
-        </AuthenticatedLayout>
-    );
+          </div>
+
+          <div className="max-w-5xl w-full">
+            <Typography variant="h5" className="font-semibold mb-4 text-center" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+              登録済みの決済方法一覧
+            </Typography>
+
+            {registeredPayments.length > 0 ? (
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                {registeredPayments.map(payment => (
+                  <Card key={payment.id} className="shadow-md" style={{ backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper }}>
+                    {payment.image_path && (
+                      <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-cover" />
+                    )}
+                    <CardContent className="text-center">
+                      <Typography variant="h6" className="font-bold" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+                        {payment.name}
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            ) : (
+              <Typography variant="body1" className="text-center mt-4" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+                現在、登録済みの決済方法はありません。
+              </Typography>
+            )}
+          </div>
+        </div>
+      </AuthenticatedLayout>
+    </ThemeProvider>
+  );
 }

--- a/resources/js/Pages/bestpayment/best.jsx
+++ b/resources/js/Pages/bestpayment/best.jsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
-import Authenticated from "@/Layouts/AuthenticatedLayout";
-import { Button, TextField, Checkbox, FormControlLabel, Typography, Paper, Box } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { ThemeProvider, CssBaseline, Button, TextField, Checkbox, FormControlLabel, Typography, Switch, Card, CardContent } from '@mui/material';
 import { useForm, usePage } from '@inertiajs/react';
 import { Inertia } from '@inertiajs/inertia';
+import { lightTheme, darkTheme } from '@/Themes/theme';
+import Authenticated from "@/Layouts/AuthenticatedLayout";
 
 const Best = (props) => {
     const { payments, keyword, onlymypayment } = usePage().props;
@@ -11,76 +12,96 @@ const Best = (props) => {
         onlymypayment: onlymypayment || false,
     });
 
+    const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark');
+
+    useEffect(() => {
+        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+    }, [darkMode]);
+
     const handleSearch = (e) => {
         e.preventDefault();
         post('/best');
     };
 
     return (
-        <Authenticated auth={props.auth} header={
-            <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold', color: '#333' }}>
-                Best Payment Search
-            </Typography>
-        }>
-            <Box sx={{ padding: 3 }}>
-                <Paper sx={{ padding: 3, backgroundColor: '#f5f5f5' }}>
-                    <Typography variant="h6" sx={{ marginBottom: 2, color: '#333' }}>BESTPAYMENT</Typography>
+        <ThemeProvider theme={darkMode ? darkTheme : lightTheme}>
+            <CssBaseline />
+            <Authenticated auth={props.auth}>
+                {/* ダークモード切り替えスイッチ */}
+                <div style={{ position: 'absolute', top: 10, right: 60 }}>
+                    <FormControlLabel
+                        control={
+                            <Switch 
+                                checked={darkMode} 
+                                onChange={() => setDarkMode(!darkMode)}
+                                name="themeSwitch"
+                                color="primary"
+                            />
+                        }
+                        label={<span style={{ color: darkMode ? '#fff' : '#000' }}> {darkMode ? "D" : "L"} </span>}
+                    />
+                </div>
 
-                    <form onSubmit={handleSearch}>
-                        <Box sx={{ display: 'flex', gap: 2, marginBottom: 2 }}>
+                <div className="p-8 min-h-screen flex flex-col items-center" style={{ backgroundColor: darkMode ? darkTheme.palette.background.default : lightTheme.palette.background.default }}>
+                    <Typography variant="h4" className="font-bold text-center mb-8" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+                        お得な支払い方法を探す
+                    </Typography>
+
+                    <div className="max-w-xl w-full shadow-md rounded-lg p-6 mb-10" style={{ backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper }}>
+                        <form onSubmit={handleSearch}>
                             <TextField
                                 label="店名を入力してください"
                                 variant="outlined"
                                 fullWidth
                                 value={data.searchQuery}
                                 onChange={(e) => setData('searchQuery', e.target.value)}
+                                sx={{
+                                    backgroundColor: darkMode ? darkTheme.palette.background.default : '#fff',
+                                    color: darkMode ? darkTheme.palette.text.primary : '#000',
+                                    '& .MuiInputLabel-root': { color: darkMode ? darkTheme.palette.text.primary : '#333' },
+                                    '& .MuiOutlinedInput-root': {
+                                        '& fieldset': { borderColor: '#ccc' },
+                                        '&:hover fieldset': { borderColor: '#888' },
+                                    }
+                                }}
                             />
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                type="submit"
-                                sx={{ alignSelf: 'center' }}
-                            >
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={data.onlymypayment}
+                                        onChange={(e) => setData('onlymypayment', e.target.checked)}
+                                    />
+                                }
+                                label={<span style={{ color: darkMode ? darkTheme.palette.text.primary : '#000' }}>登録済み</span>}
+                            />
+                            <Button variant="contained" type="submit" className="w-full mt-4">
                                 検索
                             </Button>
-                        </Box>
+                        </form>
+                    </div>
 
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={data.onlymypayment}
-                                    onChange={(e) => setData('onlymypayment', e.target.checked)}
-                                />
-                            }
-                            label="登録済み"
-                            sx={{ marginBottom: 2 }}
-                        />
-                    </form>
-
-                    <Box sx={{ marginTop: 3 }}>
-                        <Typography variant="subtitle1" sx={{ marginBottom: 1, color: '#555' }}>
-                            {payments.length > 0 ? '結果:' : 'そのような店は見つかりません。'}
-                        </Typography>
-                        <ul style={{ listStyleType: 'none', paddingLeft: 0 }}>
-                            {payments.length > 0 ? (
-                                payments.map(payment => (
-                                    <li key={payment.id} style={{
-                                        padding: '10px',
-                                        borderBottom: '1px solid #ddd',
-                                        borderRadius: '5px',
-                                        backgroundColor: '#fff',
-                                        marginBottom: '8px',
-                                    }}>
-                                        <Typography variant="body1">{payment.name}</Typography>
-                                    </li>
-                                ))
-                            ) : null}
-                        </ul>
-                    </Box>
-                </Paper>
-            </Box>
-        </Authenticated>
+                    <div className="max-w-5xl w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                        {payments.length > 0 ? (
+                            payments.map(payment => (
+                                <Card key={payment.id} className="shadow-md" style={{ backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper }}>
+                                    {payment.image_path && (
+                                        <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-cover" />
+                                    )}
+                                    <CardContent className="text-center">
+                                        <Typography variant="h6" className="font-bold" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+                                            {payment.name}
+                                        </Typography>
+                                    </CardContent>
+                                </Card>
+                            ))
+                        ) : (
+                            <Typography className="text-center text-gray-600">見つかりませんでした。</Typography>
+                        )}
+                    </div>
+                </div>
+            </Authenticated>
+        </ThemeProvider>
     );
-}
+};
 
 export default Best;

--- a/resources/js/Themes/theme.js
+++ b/resources/js/Themes/theme.js
@@ -1,0 +1,39 @@
+import { createTheme } from '@mui/material/styles';
+
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#f19db5',
+    },
+    secondary: {
+      main: '#932993',
+    },
+    background: {
+      default: '#FFF5F8',
+      paper: '#ffffff',
+    },
+    text: {
+      primary: '#333333',
+    },
+  },
+});
+
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: {
+      main: '#5fb955',
+    },
+    secondary: {
+      main: '#932993',
+    },
+    background: {
+      default: '#1C1C1C',
+      paper: '#2C2C2C',
+    },
+    text: {
+      primary: '#F5F5F5',
+    },
+  },
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,9 +27,10 @@ Route::get('/', function () {
     ]);
 });
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', [PaymentController::class, 'dashboard'])
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
+
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
支払い方法に適切な画像を追加しました。
ログイン後の画面をホームとし、登録済みの支払い方法を閲覧できるようにしました。
右上にスイッチを配置し、櫻坂46をイメージしたライトモードと欅坂46をイメージしたダークモードにUIを切り替えられるようにしました。