### PR TITLE
検索結果で決済方法が優先度順に3つ出力されるように変更、画像のサイズ調整

### DIFF
--- a/database/seeders/PaymentstoreSeeder.php
+++ b/database/seeders/PaymentstoreSeeder.php
@@ -9,26 +9,49 @@ use App\Models\Payment;
 
 class PaymentstoreSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
     public function run()
     {
-        // 店舗と決済方法の組み合わせを定義
+      
         $storePaymentPairs = [
-            ['store_name' => 'イオン', 'payment_name' => 'イオンカード'],
-            ['store_name' => 'ローソン', 'payment_name' => '三井住友カード'],
-            ['store_name' => 'セブンイレブン', 'payment_name' => '三井住友カード'],
-            ['store_name' => 'まいばすけっと', 'payment_name' => 'イオンカード'],
-            ['store_name' => 'ライフ', 'payment_name' => '楽天ペイ'],
-            ['store_name' => '成城石井', 'payment_name' => 'エポスカード'],
-            ['store_name' => '西友', 'payment_name' => 'エポスカード'],
-            ['store_name' => 'ヤオコー', 'payment_name' => 'エポスカード'],
-            ['store_name' => 'ファミリーマート', 'payment_name' => 'FamiPay'],
-            ['store_name' => 'ロピア', 'payment_name' => '現金'],
-
+            
+            ['store_name' => 'イオン', 'payment_name' => 'イオンカード', 'priority' => 1],
+            ['store_name' => 'イオン', 'payment_name' => '楽天ペイ',  'priority' => 2],
+            ['store_name' => 'イオン', 'payment_name' => 'PayPay',      'priority' => 3],
+           
+            ['store_name' => '西友', 'payment_name' => '楽天ペイ', 'priority' => 1],
+            ['store_name' => '西友', 'payment_name' => 'PayPay',       'priority' => 2],
+            ['store_name' => '西友', 'payment_name' => 'エポスカード',          'priority' => 3],
+          
+            ['store_name' => 'ロピア', 'payment_name' => '現金', 'priority' => 1],
+        
+            ['store_name' => 'まいばすけっと', 'payment_name' => 'イオンカード', 'priority' => 1],
+            ['store_name' => 'まいばすけっと', 'payment_name' => '楽天ペイ',   'priority' => 2],
+            ['store_name' => 'まいばすけっと', 'payment_name' => 'PayPay',       'priority' => 3],
+            
+            ['store_name' => 'ヤオコー', 'payment_name' => 'エポスカード', 'priority' => 1],
+            ['store_name' => 'ヤオコー', 'payment_name' => '楽天ペイ',  'priority' => 2],
+            ['store_name' => 'ヤオコー', 'payment_name' => 'PayPay',      'priority' => 3],
+           
+            ['store_name' => 'ライフ', 'payment_name' => 'JCBカード', 'priority' => 1],
+            ['store_name' => 'ライフ', 'payment_name' => 'dカード',       'priority' => 2],
+            ['store_name' => 'ライフ', 'payment_name' => '楽天ペイ',          'priority' => 3],
+          
+            ['store_name' => '成城石井', 'payment_name' => 'JCBカード', 'priority' => 1],
+            ['store_name' => '成城石井', 'payment_name' => '三井住友カード',       'priority' => 2],
+            ['store_name' => '成城石井', 'payment_name' => '楽天ペイ',          'priority' => 3],
+        
+            ['store_name' => 'ローソン', 'payment_name' => '三井住友カード', 'priority' => 1],
+            ['store_name' => 'ローソン', 'payment_name' => '三菱UFJカード',   'priority' => 2],
+            ['store_name' => 'ローソン', 'payment_name' => 'd払い',       'priority' => 3],
+            
+            ['store_name' => 'ファミリーマート', 'payment_name' => 'FamiPay', 'priority' => 1],
+            ['store_name' => 'ファミリーマート', 'payment_name' => '楽天ペイ',  'priority' => 2],
+            ['store_name' => 'ファミリーマート', 'payment_name' => 'd払い',      'priority' => 3],
+           
+            ['store_name' => 'セブンイレブン', 'payment_name' => '三井住友カード', 'priority' => 1],
+            ['store_name' => 'セブンイレブン', 'payment_name' => '三菱UFJカード',       'priority' => 2],
+            ['store_name' => 'セブンイレブン', 'payment_name' => 'JCBカード',          'priority' => 3],
+           
         ];
 
         $insertData = [];
@@ -46,12 +69,11 @@ class PaymentstoreSeeder extends Seeder
 
             $insertData[] = [
                 'payment_id' => $payment->id,
-                'store_id' => $store->id,
-                'priority' => 1,
+                'store_id'   => $store->id,
+                'priority'   => $pair['priority'],
             ];
         }
 
-        // データを一括挿入
         DB::table('payment_stores')->insert($insertData);
     }
 }

--- a/resources/js/Pages/Dashboard.jsx
+++ b/resources/js/Pages/Dashboard.jsx
@@ -19,7 +19,6 @@ export default function Dashboard({ auth, errors, payments = [], registered = []
       <AuthenticatedLayout auth={auth} errors={errors}>
         <Head title="Dashboard" />
         
-        {/* ダークモード切り替えスイッチ */}
         <div style={{ position: 'absolute', top: 10, right: 60 }}>
           <FormControlLabel
             control={
@@ -68,7 +67,7 @@ export default function Dashboard({ auth, errors, payments = [], registered = []
                 {registeredPayments.map(payment => (
                   <Card key={payment.id} className="shadow-md" style={{ backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper }}>
                     {payment.image_path && (
-                      <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-cover" />
+                      <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-contain" />
                     )}
                     <CardContent className="text-center">
                       <Typography variant="h6" className="font-bold" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>

--- a/resources/js/Pages/bestpayment/best.jsx
+++ b/resources/js/Pages/bestpayment/best.jsx
@@ -4,6 +4,7 @@ import { useForm, usePage } from '@inertiajs/react';
 import { Inertia } from '@inertiajs/inertia';
 import { lightTheme, darkTheme } from '@/Themes/theme';
 import Authenticated from "@/Layouts/AuthenticatedLayout";
+import EmojiEventsIcon from '@mui/icons-material/EmojiEvents';
 
 const Best = (props) => {
     const { payments, keyword, onlymypayment } = usePage().props;
@@ -11,6 +12,7 @@ const Best = (props) => {
         searchQuery: keyword || '',
         onlymypayment: onlymypayment || false,
     });
+    const [hasSearched, setHasSearched] = useState(false);
 
     const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark');
 
@@ -20,14 +22,39 @@ const Best = (props) => {
 
     const handleSearch = (e) => {
         e.preventDefault();
+        setHasSearched(true);
         post('/best');
+    };
+
+    const getBadgeStyle = (index) => {
+        if (index === 0) {
+            return { background: 'linear-gradient(45deg, #FFD700, #FFC107)' }; // ゴールド系
+        } else if (index === 1) {
+            return { background: 'linear-gradient(45deg, #C0C0C0, #B0BEC5)' }; // シルバー系
+        } else if (index === 2) {
+            return { background: 'linear-gradient(45deg, #CD7F32, #D2B48C)' }; // ブロンズ系
+        } else {
+            return { background: 'gray' };
+        }
+    };
+
+    const getRankTitle = (index) => {
+        if (index === 0) {
+            return '';
+        } else if (index === 1) {
+            return '';
+        } else if (index === 2) {
+            return '';
+        } else {
+            return '';
+        }
     };
 
     return (
         <ThemeProvider theme={darkMode ? darkTheme : lightTheme}>
             <CssBaseline />
             <Authenticated auth={props.auth}>
-                {/* ダークモード切り替えスイッチ */}
+
                 <div style={{ position: 'absolute', top: 10, right: 60 }}>
                     <FormControlLabel
                         control={
@@ -80,24 +107,59 @@ const Best = (props) => {
                         </form>
                     </div>
 
-                    <div className="max-w-5xl w-full grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-                        {payments.length > 0 ? (
-                            payments.map(payment => (
-                                <Card key={payment.id} className="shadow-md" style={{ backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper }}>
-                                    {payment.image_path && (
-                                        <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-cover" />
-                                    )}
-                                    <CardContent className="text-center">
-                                        <Typography variant="h6" className="font-bold" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
-                                            {payment.name}
-                                        </Typography>
-                                    </CardContent>
-                                </Card>
-                            ))
-                        ) : (
-                            <Typography className="text-center text-gray-600">見つかりませんでした。</Typography>
-                        )}
-                    </div>
+                    {hasSearched && data.searchQuery.trim() !== "" && (
+                        <div className="max-w-5xl w-full flex flex-col gap-6">
+                            {payments.length > 0 ? (
+                                payments.map((payment, index) => (
+                                    <Card 
+                                        key={payment.id} 
+                                        className="shadow-md"
+                                        style={{ 
+                                            backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper,
+                                            maxWidth: '400px',
+                                            width: '100%',
+                                            margin: '0 auto'
+                                        }}
+                                    >
+                                        <CardContent>
+                                            
+                                            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '16px' }}>
+                                                <div 
+                                                    style={{
+                                                        ...getBadgeStyle(index),
+                                                        borderRadius: '50%',
+                                                        width: '60px',
+                                                        height: '60px',
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        justifyContent: 'center',
+                                                        boxShadow: '0 4px 8px rgba(0,0,0,0.3)'
+                                                    }}
+                                                >
+                                                    <Typography variant="h5" style={{ color: '#fff', fontWeight: 'bold' }}>
+                                                        {index + 1}
+                                                    </Typography>
+                                                </div>
+                                                <div style={{ marginLeft: '16px' }}>
+                                                    <Typography variant="h6" style={{ fontWeight: 'bold', color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+                                                        {getRankTitle(index)}
+                                                    </Typography>
+                                                </div>
+                                            </div>
+                                            {payment.image_path && (
+                                                <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-contain mb-2" />
+                                            )}
+                                            <Typography variant="h6" className="font-bold" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>
+                                                {payment.name}
+                                            </Typography>
+                                        </CardContent>
+                                    </Card>
+                                ))
+                            ) : (
+                                <Typography className="text-center text-gray-600">見つかりませんでした。</Typography>
+                            )}
+                        </div>
+                    )}
                 </div>
             </Authenticated>
         </ThemeProvider>

--- a/resources/js/Pages/bestpayment/index.jsx
+++ b/resources/js/Pages/bestpayment/index.jsx
@@ -38,7 +38,7 @@ const Index = ({ auth, payments, registered, message }) => {
             <CssBaseline />
             <Authenticated auth={auth}>
 
-                {/* ライト／ダークモード切り替えスイッチ */}
+
                 <div style={{ position: 'absolute', top: 10, right: 60 }}>
                     <FormControlLabel
                         control={
@@ -67,7 +67,7 @@ const Index = ({ auth, payments, registered, message }) => {
                             payments.map(payment => (
                                 <Card key={payment.id} className="shadow-md" style={{ backgroundColor: darkMode ? darkTheme.palette.background.paper : lightTheme.palette.background.paper }}>
                                     {payment.image_path && (
-                                        <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-cover" />
+                                        <img src={payment.image_path} alt={payment.name} className="h-32 w-full object-contain" />
                                     )}
                                     <CardContent className="text-center">
                                         <Typography variant="h6" className="font-bold" style={{ color: darkMode ? darkTheme.palette.text.primary : lightTheme.palette.text.primary }}>


### PR DESCRIPTION
登録済みのフィルタリングの際、上の順位のものが登録されていなった場合、それより下位のものの繰り上げができるようにしている。
画面サイズによって見切れていた画像を調整し、適切なサイズにした。